### PR TITLE
Fix: allow lowercase sublevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of planned features, see [the roadmap](ROADMAP.md).
 
+## Unreleased
+
+- *CHANGED* `LOGGIA_SUB_LEVEL` and [set_logger_level](loggia.conf.LoggerConfiguration.set_logger_level) now accept a lowercase strings and ints as well as uppercase strings.
+
 ## 0.3.0 - 2024-01-22
 
 _Initial Open Source Release!_

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -56,10 +56,10 @@ across several deployments, we recommend you try writing a preset instead.
 
 Pending a better tutorial, look at the packages in the [`loggia.presets`][loggia.presets] namespace for
 inspiration. In most instances, you can cut and paste your Loggia configuration code
-in an `apply` method and be done with it.
+in an [`apply`][loggia.base_preset.BasePreset.apply]method and be done with it.
 
 !!! note
-    The ROADMAP includes several tasks where we plan on expanding / reworking this side.
+    The [ROADMAP](/ROADMAP.md) includes several tasks where we plan on expanding / reworking this side.
     We notably intend to clarify how to ship presets, add more pythonic ways of registering
     new presets, and provide a mechanism for conditional activation beyond preset-preset
     dependencies.
@@ -76,7 +76,7 @@ register the type.
 ### Declaring a preset-preset dependency
 
 If your preset should be enabled depending on whether or not another preset is activating,
-you may override the `BasePreset.required_presets()` class method to indicate which presets
+you may override the [`BasePreset.required_presets()`][loggia.base_preset.BasePreset.required_presets] class method to indicate which presets
 you depend on.
 
 For instance, an hypothetic `AddProductionFields` would likely depend on the `prod` preset.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,5 +15,11 @@
       show_source: False
       show_bases: False
       show_signature: False
+::: loggia.base_preset
+    options:
+      show_object_full_path: True
+      show_source: False
+      show_bases: False
+      show_signature: False
 ::: loggia.constants.BASE_DICTCONFIG
     show_source: True

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,6 +80,8 @@ See the [Presets documentation](presets.md) for more information.
 
 You probably want to configure the standard Python logger as well, e.g., to change the log level for some libraries.
 
+This is done using environment variables `LOGGIA_SUB_LEVEL`, or by using calling [set_logger_level][loggia.conf.LoggerConfiguration.set_logger_level].
+
 ```python
 {%
     include "../tests/test_usage_docs/test_usage_custom_config.py"

--- a/loggia/logger.py
+++ b/loggia/logger.py
@@ -24,7 +24,6 @@ def _patch_to_add_level(level_number: int, level_name: str) -> None:
     # pylint: disable=protected-access
     # ruff: noqa: SLF001
     level_name_upper = level_name.upper()
-    level_name.lower()
     logging.addLevelName(level_number, level_name_upper)
 
 

--- a/loggia/utils/strutils.py
+++ b/loggia/utils/strutils.py
@@ -9,3 +9,11 @@ _snake_case_re = re.compile(r"(?<!^)(?=[A-Z])")
 # XXX Tests
 def to_snake_case(s: str) -> str:
     return _snake_case_re.sub("_", s).lower()
+
+
+def clean_log_level(level: str | int) -> str | int:
+    if isinstance(level, str):
+        level = level.upper()
+        if level.isdigit():
+            level = int(level)
+    return level

--- a/tests/test_basics/test_propagate.py
+++ b/tests/test_basics/test_propagate.py
@@ -13,8 +13,34 @@ if TYPE_CHECKING:
 
 def test_child_high_root_low(capjson: JsonStderrCaptureFixture):
     conf = LoggerConfiguration()
-    conf.set_general_level = "INFO"
-    conf.set_logger_level("test", "WARN")
+    conf.set_general_level("INFO")
+    conf.set_logger_level("test", "warn")
+    initialize(conf)
+
+    logger = logging.getLogger("test")
+    logger.warning("should go through")
+    logger.info("should not go through")
+
+    assert len(capjson.records) == 1
+
+
+def test_child_high_root_low_lower(capjson: JsonStderrCaptureFixture):
+    conf = LoggerConfiguration()
+    conf.set_general_level("info")
+    conf.set_logger_level("test", "warn")
+    initialize(conf)
+
+    logger = logging.getLogger("test")
+    logger.warning("should go through")
+    logger.info("should not go through")
+
+    assert len(capjson.records) == 1
+
+
+def test_child_high_root_low_int(capjson: JsonStderrCaptureFixture):
+    conf = LoggerConfiguration()
+    conf.set_general_level(logging.INFO)
+    conf.set_logger_level("test", logging.WARNING)
     initialize(conf)
 
     logger = logging.getLogger("test")
@@ -26,7 +52,7 @@ def test_child_high_root_low(capjson: JsonStderrCaptureFixture):
 
 def test_child_low_root_high(capjson: JsonStderrCaptureFixture):
     conf = LoggerConfiguration()
-    conf.set_general_level = "ERROR"
+    conf.set_general_level("ERROR")
     conf.set_logger_level("test", "INFO")
     initialize(conf)
 

--- a/tests/test_util/test_dictutils.py
+++ b/tests/test_util/test_dictutils.py
@@ -44,7 +44,11 @@ def test_deep_merge_log_config():
         "handlers": {"console": {"class": "logging.StreamHandler", "formatter": "simple"}},
     }
 
-    opt_dict_cfg: logging.config._OptionalDictConfigArgs = {"handlers": {"console": {"level": "INFO"}}, "root": {"handlers": ["console"]}}
+    opt_dict_cfg: logging.config._DictConfigArgs = {
+        "version": 1,
+        "handlers": {"console": {"level": "INFO"}},
+        "root": {"handlers": ["console"]},
+    }
 
     # Expected result
     expected: logging.config._DictConfigArgs = {

--- a/tests/test_util/test_jsonencoder.py
+++ b/tests/test_util/test_jsonencoder.py
@@ -17,9 +17,9 @@ def test_json_dunder_ok():
 # We skip this because it's ahead of its time. We could revisit with
 # either homegrown checking, or better support from standard library.
 #
-# python/3.11.3/lib/python3.11/typing.py:2223
-# Warning: this will check only the presence of the required methods,
-# not their type signatures!
+# python/3.11.3/lib/python3.11/typing.py:2223 (runtime_checkable)
+# > Warning: this will check only the presence of the required methods,
+# > not their type signatures!
 @pytest.mark.skip("ahead of its time")
 def test_json_dunder_ko_type():
     class JsonEncodable:
@@ -27,6 +27,6 @@ def test_json_dunder_ko_type():
             return 1
 
     if isinstance(JsonEncodable(), JsonSerializable):
-        raise RuntimeError("Z")
+        raise RuntimeError("This should not be true")
     output = json.dumps(JsonEncodable(), cls=CustomJsonEncoder)
     assert output == "ok"


### PR DESCRIPTION
Previously, setting `LOGGIA_SUB_LEVEL=httpx:info` would raise an error, and only `LOGGIA_SUB_LEVEL=httpx:INFO` would be valid.

Thins brings this setting more in line with the general log level setting, and is not a breaking change.

Note: this MR also add some links in the documentation, and fixes some typings issues on tests.