### PR TITLE
fix: skip import of ddtrace if DD_TRACE_ENABLED is falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ For a list of planned features, see [the roadmap](ROADMAP.md).
 ## Unreleased
 
 - *CHANGED* `LOGGIA_SUB_LEVEL` and [set_logger_level](loggia.conf.LoggerConfiguration.set_logger_level) now accept a lowercase strings and ints as well as uppercase strings.
+- *FIXED* `ddtrace` was imported even with `DD_TRACE_ENABLED=false`
 
 ## 0.3.0 - 2024-01-22
 

--- a/loggia/logger.py
+++ b/loggia/logger.py
@@ -72,7 +72,6 @@ def initialize(conf: LoggerConfiguration | dict[str, str] | None = None, presets
                 bootstrap_logger.error("Failed to configure loguru! Is is installed?", e)
 
     # XXX Check that logger levels exists
-
     # BIM BAM BADABEEM BADABOOM, LOGGIA MAGICA!
     logging.config.dictConfig(conf._dictconfig)
 

--- a/loggia/presets/datadog_normalisation.py
+++ b/loggia/presets/datadog_normalisation.py
@@ -1,10 +1,13 @@
 """Remap anything to Datadog standard and common attributes."""
 from __future__ import annotations
 
+import os
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
+from loggia._internal.bootstrap_logger import bootstrap_logger
+from loggia._internal.conf import is_truthy_string
 from loggia.base_preset import BasePreset
 
 if sys.version_info >= (3, 10):
@@ -22,11 +25,14 @@ if TYPE_CHECKING:
 
 ExcInfo: TypeAlias = "tuple[type[BaseException], BaseException, None | TracebackType]"
 
-
-try:
-    import ddtrace
-except ImportError:
-    ddtrace = None  # type: ignore[assignment]
+# XXX(GabDug): cleanup ddtrace import
+DD_TRACE_ENABLED: Final[bool | None] = is_truthy_string(os.environ.get("DD_TRACE_ENABLED", False))
+if DD_TRACE_ENABLED:
+    try:
+        import ddtrace
+    except ImportError:
+        bootstrap_logger.error("DD_TRACE_ENABLED environment variable is set but ddtrace package cannot be loaded")
+        ddtrace = None  # type: ignore[assignment]
 
 try:
     from loggia._version import __version__

--- a/loggia/stdlib_formatters/json_formatter.py
+++ b/loggia/stdlib_formatters/json_formatter.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from pythonjsonlogger.jsonlogger import RESERVED_ATTRS, JsonEncoder, JsonFormatter
 
 from loggia._internal.bootstrap_logger import bootstrap_logger
+from loggia._internal.conf import is_truthy_string
 from loggia.constants import SAFE_HEADER_ATTRIBUTES
 from loggia.utils.dictutils import del_if_possible, del_many_if_possible, mv_attr
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     import logging
 
 GUNICORN_KEY_RE = re.compile("{([^}]+)}")
-DD_TRACE_ENABLED: Final[str | None] = os.environ.get("DD_TRACE_ENABLED")
+DD_TRACE_ENABLED: Final[bool | None] = is_truthy_string(os.environ.get("DD_TRACE_ENABLED", False))
 if DD_TRACE_ENABLED:
     try:
         from ddtrace import tracer


### PR DESCRIPTION
- ddtrace should not be imported by datadog preset if `DD_TRACE_ENABLED`
- `DD_TRACE_ENABLED` should be falsy if set to `false` (atm, only falsy when empty)
- We probably want to remove Datadog specific presets from base presets in a future version