### PR TITLE
feat: test and support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # Empty is latest, head is latest from GitHub
         pdm-version: [""]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of planned features, see [the roadmap](ROADMAP.md).
 
 ## Unreleased
 
+- Test using Python 3.13
+
+## 0.3.1 - 2024-04-03
+
 - *CHANGED* `LOGGIA_SUB_LEVEL` and [set_logger_level][loggia.conf.LoggerConfiguration.set_logger_level] now accept a lowercase strings and ints as well as uppercase strings.
 - *FIXED* `ddtrace` was imported even with `DD_TRACE_ENABLED=false`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Loggia is **not** a new Python logger - it's a nice way to configure - and share
 
 ## Supported versions
 
-We currently support Python 3.9, 3.10, 3.11 and 3.12.
+We currently support Python 3.9, 3.10, 3.11, 3.12 and 3.13.
 
 We may drop the support for a Python version before its end of life, to keep the codebase up to date with the latest Python features: i.e.: we will endeavor to support either the last 3 or 4 stable Python releases.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Typing :: Typed",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: System :: Logging",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{9,10,11,12}-loguru{0,1}-ddtrace{0,1}
+envlist = py3{9,10,11,12,13}-loguru{0,1}-ddtrace{0,1}
 isolated_build = True  ; This is required for a pyproject.toml based project.
 
 [testenv]


### PR DESCRIPTION
Currently blocked as `ddtrace` does not support CPython 3.13 yet (see https://github.com/DataDog/dd-trace-py/issues/10932)